### PR TITLE
Properly escape inline JSON as HTML

### DIFF
--- a/router/router.py
+++ b/router/router.py
@@ -412,7 +412,7 @@ class Handler(SimpleHTTPServer.SimpleHTTPRequestHandler):
             if 'json' in self.headers.getheader('Accept', ''):
                 self.generate(j, 'application/json')
             else:
-                j = j.replace("</", "<\\/")
+                j = j.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
                 template = os.path.join(index_path(tree_name), 'templates/search.html')
                 self.generateWithTemplate({'{{BODY}}': j, '{{TITLE}}': 'Search'}, template)
         elif path_elts[1] == 'define':


### PR DESCRIPTION
Simply replacing `</` with `<\/` is not sufficient for escaping HTML, because `<script>` and `<!--` have a special meaning in the HTML5 parser too.

Besides that, not escaping `&` leads to edge cases where the result is incorrectly interpreted.
