### PR TITLE
Newline fixes

### DIFF
--- a/tools/src/tokenize.rs
+++ b/tools/src/tokenize.rs
@@ -288,7 +288,7 @@ pub fn tokenize_c_like(string: &String, spec: &LanguageSpec) -> Vec<Token> {
                         while peek_char() != ']' {
                             get_char();
                         }
-                    } else if next == '\\' {
+                    } else if next == '\\' && peek_char() != '\n' {
                         get_char();
                     } else if next == '\n' {
                         writeln!(&mut std::io::stderr(), "Invalid regexp literal").unwrap();


### PR DESCRIPTION
I was reading the code over the weekend and realized that my patch to add C++ raw literals didn't handle newlines properly, which seems like a bug that's worth fixing. In doing so, I noticed that the code to split a token across a newline was duplicated a couple of times so I pulled it out -- that being said, I'm a little surprised that I had to explicitly pass `tokens` in as a `&mut Vec<>`. Do you know why that's required?

I also fixed error reporting for illegal regexps ending with an escaped newline. It probably isn't a big deal, but we handle that case correctly in the string literal code, so I figured it was worth being consistent.