### PR TITLE
Recognize moz.configure as Python

### DIFF
--- a/tools/src/languages.rs
+++ b/tools/src/languages.rs
@@ -191,7 +191,7 @@ pub fn select_formatting(filename: &str) -> FormatAs {
         "idl" => FormatAs::FormatCLike(&*IDL_SPEC),
         "webidl" => FormatAs::FormatCLike(&*WEBIDL_SPEC),
         "js" | "jsm" | "json" => FormatAs::FormatCLike(&*JS_SPEC),
-        "py" | "build" => FormatAs::FormatCLike(&*PYTHON_SPEC),
+        "py" | "build" | "configure" => FormatAs::FormatCLike(&*PYTHON_SPEC),
 
         "html" | "htm" | "xhtml" | "xml" | "xul" => FormatAs::FormatTagLike(&*JS_SPEC),
 


### PR DESCRIPTION
I noticed recently that *.configure files in the tree weren't being recognized as Python.