### PR TITLE
Add link to Raw file

### DIFF
--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -136,6 +136,10 @@ fn main() {
                     title: "Log".to_owned(),
                     link: format!("https://hg.mozilla.org/mozilla-central/log/tip/{}", path),
                     update_link_lineno: false,
+                 }, PanelItem {
+                    title: "Raw".to_owned(),
+                    link: format!("https://hg.mozilla.org/mozilla-central/raw-file/{}/{}", oid, path),
+                    update_link_lineno: false,
                 }, PanelItem {
                     title: "Blame".to_owned(),
                     link: "javascript:alert('Hover over the gray bar on the left to see blame information.')".to_owned(),

--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -138,7 +138,7 @@ fn main() {
                     update_link_lineno: false,
                  }, PanelItem {
                     title: "Raw".to_owned(),
-                    link: format!("https://hg.mozilla.org/mozilla-central/raw-file/{}/{}", oid, path),
+                    link: format!("https://raw.githubusercontent.com/mozilla/gecko-dev/{}/{}", oid, path),
                     update_link_lineno: false,
                 }, PanelItem {
                     title: "Blame".to_owned(),


### PR DESCRIPTION
This changeset adds a link to the raw file on hg.mozilla.org. Comes in handy for SVG files, for example.