### PR TITLE
tools: Remove unneeded indirections in a few places.

### DIFF
--- a/tools/src/bin/ipdl-analyze.rs
+++ b/tools/src/bin/ipdl-analyze.rs
@@ -46,7 +46,7 @@ fn mangle_simple(s: &str) -> String {
     format!("{}{}", s.len(), s)
 }
 
-fn mangle_nested_name(ns: &Vec<String>, protocol: &str, name: &str) -> String {
+fn mangle_nested_name(ns: &[String], protocol: &str, name: &str) -> String {
     format!("_ZN{}{}{}E",
             ns.iter().map(|id| mangle_simple(&id)).collect::<Vec<_>>().join(""),
             mangle_simple(protocol),

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -21,8 +21,8 @@ use chrono::datetime::DateTime;
 use config;
 
 pub fn format_code(jumps: &HashMap<String, Jump>, format: FormatAs,
-                   path: &str, input: &String,
-                   analysis: &Vec<WithLocation<Vec<AnalysisSource>>>) -> (Vec<String>, String)
+                   path: &str, input: &str,
+                   analysis: &[WithLocation<Vec<AnalysisSource>>]) -> (Vec<String>, String)
 {
     let tokens = match format {
         FormatAs::Binary => panic!("Unexpected binary file"),
@@ -222,13 +222,13 @@ fn read_blob_entry(repo: &git2::Repository, entry: &git2::TreeEntry) -> String {
 
 pub fn format_file_data(cfg: &config::Config,
                         tree_name: &str,
-                        panel: &Vec<PanelSection>,
+                        panel: &[PanelSection],
                         commit: Option<&git2::Commit>,
                         blame_commit: Option<&git2::Commit>,
                         path: &str,
                         data: String,
                         jumps: &HashMap<String, Jump>,
-                        analysis: &Vec<WithLocation<Vec<AnalysisSource>>>,
+                        analysis: &[WithLocation<Vec<AnalysisSource>>],
                         writer: &mut Write) -> Result<(), &'static str>  {
     let tree_config = try!(cfg.trees.get(tree_name).ok_or("Invalid tree"));
 

--- a/tools/src/languages.rs
+++ b/tools/src/languages.rs
@@ -14,7 +14,7 @@ pub struct LanguageSpec {
     pub rust_tweaks: bool,
 }
 
-fn make_reserved(v: &Vec<&str>) -> HashMap<String, String> {
+fn make_reserved(v: &[&str]) -> HashMap<String, String> {
     let mut reserved_words = HashMap::new();
     for word in v {
         reserved_words.insert(word.to_string(), "style=\"color: blue;\" ".to_string());

--- a/tools/src/output.rs
+++ b/tools/src/output.rs
@@ -261,7 +261,7 @@ pub struct PanelSection {
     pub items: Vec<PanelItem>,
 }
 
-pub fn generate_panel(writer: &mut Write, sections: &Vec<PanelSection>) -> Result<(), &'static str> {
+pub fn generate_panel(writer: &mut Write, sections: &[PanelSection]) -> Result<(), &'static str> {
     let sections = sections.iter().map(|section| {
         let items = section.items.iter().map(|item| {
             let update_attr = if item.update_link_lineno {

--- a/tools/src/tokenize.rs
+++ b/tools/src/tokenize.rs
@@ -29,7 +29,7 @@ fn is_whitespace(ch : char) -> bool {
     ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r'
 }
 
-pub fn tokenize_plain(string: &String) -> Vec<Token> {
+pub fn tokenize_plain(string: &str) -> Vec<Token> {
     let lines = string.split('\n');
     let mut tokens = Vec::new();
     let mut start = 0;
@@ -55,7 +55,7 @@ pub fn tokenize_plain(string: &String) -> Vec<Token> {
     tokens
 }
 
-pub fn tokenize_c_like(string: &String, spec: &LanguageSpec) -> Vec<Token> {
+pub fn tokenize_c_like(string: &str, spec: &LanguageSpec) -> Vec<Token> {
     fn is_ident(ch: char) -> bool {
         (ch == '_') || ch.is_alphabetic() || ch.is_digit(10)
     }
@@ -467,7 +467,7 @@ pub fn tokenize_c_like(string: &String, spec: &LanguageSpec) -> Vec<Token> {
     tokens
 }
 
-pub fn tokenize_tag_like(string: &String, script_spec: &LanguageSpec) -> Vec<Token> {
+pub fn tokenize_tag_like(string: &str, script_spec: &LanguageSpec) -> Vec<Token> {
     fn is_ident(ch: char) -> bool {
         ch == '.' || ch == '_' || ch == '-' || ch == ':' || ch.is_alphabetic() || ch.is_digit(10)
     }
@@ -787,7 +787,7 @@ pub fn tokenize_tag_like(string: &String, script_spec: &LanguageSpec) -> Vec<Tok
         _ => {},
     }
 
-    fn peek(tag_stack: &Vec<&str>, index: usize, check: &str) -> bool {
+    fn peek(tag_stack: &[&str], index: usize, check: &str) -> bool {
         if tag_stack.len() <= index {
             return false;
         }


### PR DESCRIPTION
There's never a need to use `&Vec<T>` over `&[T]`, since they're always
immutable.

Similarly, there's never a reason for using `&String` over `&str`.