### PR TITLE
blame: Linkify servo PR in commit message headers.

### DIFF
--- a/tools/src/blame.rs
+++ b/tools/src/blame.rs
@@ -9,9 +9,27 @@ use chrono::naive::datetime::NaiveDateTime;
 use chrono::offset::fixed::FixedOffset;
 use chrono::datetime::DateTime;
 
-pub fn linkify(s: &str) -> String {
-    let re = Regex::new(r"\b(?P<bugno>[1-9][0-9]{4,9})\b").unwrap();
-    re.replace_all(s, "<a href=\"https://bugzilla.mozilla.org/show_bug.cgi?id=$bugno\">$bugno</a>")
+fn linkify_commit_header(s: &str) -> String {
+    lazy_static! {
+        static ref BUG_NUMBER_REGEX: Regex = {
+            Regex::new(r"\b(?P<bugno>[1-9][0-9]{4,9})\b").unwrap()
+        };
+        static ref SERVO_PR_REGEX: Regex = {
+            Regex::new(r"#(?P<prno>[1-9][0-9]*)\b").unwrap()
+        };
+    }
+    if s.starts_with("servo: ") {
+        SERVO_PR_REGEX.replace_all(s, "#<a href=\"https://github.com/servo/servo/pull/$prno\">$prno</a>")
+    } else {
+        BUG_NUMBER_REGEX.replace_all(s, "<a href=\"https://bugzilla.mozilla.org/show_bug.cgi?id=$bugno\">$bugno</a>")
+    }
+}
+
+#[test]
+fn test_linkify_servo_pr() {
+    let linkified =
+        linkify_commit_header("servo: Merge #1234 - stylo: Report a specific error for invalid CSS color values (from jdm:valueerr); r=heycam");
+    assert!(linkified.contains("github.com"), "{:?}", linkified);
 }
 
 pub fn commit_header(commit: &git2::Commit) -> Result<(String, String), &'static str> {
@@ -23,7 +41,7 @@ pub fn commit_header(commit: &git2::Commit) -> Result<(String, String), &'static
     let mut iter = msg.split('\n');
     let header = iter.next().unwrap();
     let remainder = iter.collect::<Vec<_>>().join("\n");
-    let header = linkify(&entity_replace(header));
+    let header = linkify_commit_header(&entity_replace(header));
     Ok((header, entity_replace(&remainder)))
 }
 


### PR DESCRIPTION
While at it, also avoid creating a regex each time that function is called.