### PR TITLE
Use only half of available system memory for vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,20 @@ Vagrant.configure("2") do |config|
   config.vm.network :forwarded_port, guest: 80, host: 8000
 
   config.vm.provider "virtualbox" do |v|
-    v.memory = 32768
+    host = RbConfig::CONFIG['host_os']
+    if host =~ /darwin/
+      # sysctl returns Bytes and we need to convert to MB
+      mem = `sysctl -n hw.memsize`.to_i / 1024
+    elsif host =~ /linux/
+      # meminfo shows KB and we need to convert to MB
+      mem = `grep 'MemTotal' /proc/meminfo | sed -e 's/MemTotal://' -e 's/ kB//'`.to_i
+    elsif host =~ /mswin|mingw|cygwin/
+      # Windows code via https://github.com/rdsubhas/vagrant-faster
+      mem = `wmic computersystem Get TotalPhysicalMemory`.split[1].to_i / 1024
+    end
+
+    # Give VM 1/2 system memory
+    v.memory = mem / 1024 / 2
     v.cpus = 4
   end
 end


### PR DESCRIPTION
When indexing m-c it was slowing down the my host. This change makes it use only half of the available memory - it should be testable after applying the PR via:

```
vagrant reload
vagrant ssh
grep 'MemTotal' /proc/meminfo | sed -e 's/MemTotal://' -e 's/ kB//'
```

For me it does seem to use half of my system memory
